### PR TITLE
fixed rendering issue.

### DIFF
--- a/cs464-group-project/src/components/Api/ApiRequest.js
+++ b/cs464-group-project/src/components/Api/ApiRequest.js
@@ -62,7 +62,4 @@ export async function getTeamLogos() {
   }
 }
 
-//automatically call it to populate the array at the start
-await getTeamLogos();
-
 export { allTeamLogos };

--- a/cs464-group-project/src/pages/Home.js
+++ b/cs464-group-project/src/pages/Home.js
@@ -5,6 +5,7 @@ export function Home() {
   useEffect(() => {
     async function fetchData() {
       try {
+        await getTeamLogos();
         console.log(allTeamLogos);
       } catch (error) {
         console.error('Error fetching team logos:', error.message);


### PR DESCRIPTION
Delete the function call in apirequest.js to fix rendering issue.  You will have to call the getTeamLogos first before being able to use the stored array.