### PR TITLE
Display next date and time of Live Events

### DIFF
--- a/cs464-group-project/src/components/Api/ApiRequest.js
+++ b/cs464-group-project/src/components/Api/ApiRequest.js
@@ -133,3 +133,15 @@ export async function getMilestonessById(id) {
 export async function getHistoryLeagues() {
   return await theSportsDB.getTeamDetailsById(133602);
 }
+
+export async function getNextLiveEvents(leagueId) {
+  try {
+    const response = await axios.get(
+      `https://www.thesportsdb.com/api/v1/json/${apiKey}/eventsnextleague.php?id=${leagueId}`,
+    );
+    return response.data;
+  } catch (error) {
+    console.error(`Error getting next live events : , ${error.message}`);
+    throw error;
+  }
+}

--- a/cs464-group-project/src/pages/Home.js
+++ b/cs464-group-project/src/pages/Home.js
@@ -10,6 +10,7 @@ import StadiumCap from './HomeComps/StadiumCap';
 import Table from './HomeComps/Table';
 import PastMatchTable from './HomeComps/PastMatchTable';
 import LiveMatch from './HomeComps/LiveMatch';
+import NextLiveEvents from './HomeComps/NextLiveEvents';
 
 export function Home() {
   const [stadiumCapacity, setStadiumCapacity] = useState([]);
@@ -165,7 +166,9 @@ export function Home() {
                   ) : (
                     <div className='no-live'>
                       <h2>No Live Games Currently</h2>
-                      <h2>Come Back on the Weekends!</h2>
+                      <h3>
+                        <NextLiveEvents />
+                      </h3>
                     </div>
                   )}
                 </div>

--- a/cs464-group-project/src/pages/HomeComps/NextLiveEvents.js
+++ b/cs464-group-project/src/pages/HomeComps/NextLiveEvents.js
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import { getNextLiveEvents } from '../../components/Api/ApiRequest';
+import '../../style/Home/HomeComps.css'; // Import your CSS file
+
+function NextLiveEvents() {
+  const [nextEvent, setNextEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    let leagueId = '4328'; // Currently using only the Premier League
+
+    const fetchData = async () => {
+      try {
+        const data = await getNextLiveEvents(leagueId);
+        const nextLiveEvent = data.events[0].strTimestamp;
+
+        if (isMounted) {
+          setNextEvent(nextLiveEvent);
+          setLoading(false);
+        }
+      } catch (err) {
+        console.error('Error getting next live events');
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  function formatDateTime(string) {
+    const options = {
+      month: 'short',
+      day: 'numeric',
+      weekday: 'short',
+      timeZone: 'America/Los_Angeles',
+      hour12: true,
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    };
+    return new Intl.DateTimeFormat('en-US', options).format(new Date(string));
+  }
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <div className='blink' id='next-live-events'>
+      Next Games: {formatDateTime(nextEvent)}
+    </div>
+  );
+}
+
+export default NextLiveEvents;

--- a/cs464-group-project/src/style/Home/HomeComps.css
+++ b/cs464-group-project/src/style/Home/HomeComps.css
@@ -150,3 +150,27 @@
     text-align: center;
   }
 }
+
+@keyframes blink {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.blink {
+  animation: blink 3s infinite; /* Adjust the duration as needed */
+  color: red;
+  font-size: 13px;
+}
+
+@media (min-width: 576px) {
+  .blink {
+    font-size: 20px;
+  }
+}


### PR DESCRIPTION
Added api call to get next live events.  Api returns the next 15 but, only need the first one.  Added some styling to the display also.
![next_date](https://github.com/CS464-Group-Project/CS464_GroupProject/assets/97830813/622b6c8c-0e86-4eaa-bff6-181ac217d43b)

Mobile:
![next_date_mobile](https://github.com/CS464-Group-Project/CS464_GroupProject/assets/97830813/bfcf0da6-791b-4417-8ff5-7f68bca39efb)
