### PR TITLE
FIxed upcoming Live Events

### DIFF
--- a/cs464-group-project/src/pages/HomeComps/NextLiveEvents.js
+++ b/cs464-group-project/src/pages/HomeComps/NextLiveEvents.js
@@ -13,7 +13,6 @@ function NextLiveEvents() {
     const fetchData = async () => {
       try {
         const data = await getNextLiveEvents(leagueId);
-        console.log('data received: ', data);
 
         // Sort the events.  The returned array has the time for each day is in descending order
         const sortedEvents = data.events.sort((a, b) => {
@@ -66,7 +65,6 @@ function NextLiveEvents() {
       minute: '2-digit',
       timeZoneName: 'short',
     };
-    console.log('returned date format: ', date);
     return new Intl.DateTimeFormat('en-US', options).format(new Date(date));
   }
 


### PR DESCRIPTION
It wasn't displaying the first live event, since array wasn't in ascending order of time.  Fixed by sorting array by timestamp, and then set new event.

Before: 
![next_event_before](https://github.com/CS464-Group-Project/CS464_GroupProject/assets/97830813/92e65199-618b-4762-9a09-36e50cc9a5b8)

After:
![next_event_after](https://github.com/CS464-Group-Project/CS464_GroupProject/assets/97830813/efef6e77-d022-48d2-8c5e-6e6edf91a4e4)
